### PR TITLE
trajectory_tracker_msgs: add path header in TrajectoryTrackerStatus

### DIFF
--- a/trajectory_tracker_msgs/msg/TrajectoryTrackerStatus.msg
+++ b/trajectory_tracker_msgs/msg/TrajectoryTrackerStatus.msg
@@ -7,4 +7,4 @@ Header header
 float32 distance_remains
 float32 angle_remains
 int32 status
-time path_stamp
+Header path_header

--- a/trajectory_tracker_msgs/msg/TrajectoryTrackerStatus.msg
+++ b/trajectory_tracker_msgs/msg/TrajectoryTrackerStatus.msg
@@ -7,4 +7,4 @@ Header header
 float32 distance_remains
 float32 angle_remains
 int32 status
-
+time path_stamp


### PR DESCRIPTION
path_header stores the header of corresponding path. 
This header includes exact timestamp of the path.
Stamp of path_header becomes 0 when no path has been received.