### PR TITLE
Update required cmake version

### DIFF
--- a/costmap_cspace_msgs/CMakeLists.txt
+++ b/costmap_cspace_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2...3.26)
 project(costmap_cspace_msgs)
 
 set(MESSAGE_DEPENDS

--- a/costmap_cspace_msgs/CMakeLists.txt
+++ b/costmap_cspace_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2...3.26)
+cmake_minimum_required(VERSION 3.0...3.26)
 project(costmap_cspace_msgs)
 
 set(MESSAGE_DEPENDS

--- a/map_organizer_msgs/CMakeLists.txt
+++ b/map_organizer_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2...3.26)
+cmake_minimum_required(VERSION 3.0...3.26)
 project(map_organizer_msgs)
 
 set(MESSAGE_DEPENDS

--- a/map_organizer_msgs/CMakeLists.txt
+++ b/map_organizer_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2...3.26)
 project(map_organizer_msgs)
 
 set(MESSAGE_DEPENDS

--- a/neonavigation_metrics_msgs/CMakeLists.txt
+++ b/neonavigation_metrics_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2...3.26)
+cmake_minimum_required(VERSION 3.0...3.26)
 project(neonavigation_metrics_msgs)
 
 set(MESSAGE_DEPENDS

--- a/neonavigation_metrics_msgs/CMakeLists.txt
+++ b/neonavigation_metrics_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2...3.26)
 project(neonavigation_metrics_msgs)
 
 set(MESSAGE_DEPENDS

--- a/neonavigation_msgs/CMakeLists.txt
+++ b/neonavigation_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2...3.26)
+cmake_minimum_required(VERSION 3.0...3.26)
 project(neonavigation_msgs)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/neonavigation_msgs/CMakeLists.txt
+++ b/neonavigation_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2...3.26)
 project(neonavigation_msgs)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/planner_cspace_msgs/CMakeLists.txt
+++ b/planner_cspace_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2...3.26)
+cmake_minimum_required(VERSION 3.0...3.26)
 project(planner_cspace_msgs)
 
 set(MESSAGE_DEPENDS

--- a/planner_cspace_msgs/CMakeLists.txt
+++ b/planner_cspace_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2...3.26)
 project(planner_cspace_msgs)
 
 set(MESSAGE_DEPENDS

--- a/safety_limiter_msgs/CMakeLists.txt
+++ b/safety_limiter_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2...3.26)
 project(safety_limiter_msgs)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/safety_limiter_msgs/CMakeLists.txt
+++ b/safety_limiter_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2...3.26)
+cmake_minimum_required(VERSION 3.0...3.26)
 project(safety_limiter_msgs)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/trajectory_tracker_msgs/CMakeLists.txt
+++ b/trajectory_tracker_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.0.2...3.26)
 project(trajectory_tracker_msgs)
 
 set(MESSAGE_DEPENDS

--- a/trajectory_tracker_msgs/CMakeLists.txt
+++ b/trajectory_tracker_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2...3.26)
+cmake_minimum_required(VERSION 3.0...3.26)
 project(trajectory_tracker_msgs)
 
 set(MESSAGE_DEPENDS


### PR DESCRIPTION
Allow to use cmake compatibility mode up to 3.26 to avoid error/warning on the latest cmake.
CMake 4.0 dropped 3.5 and marked 3.10 as deprecated.